### PR TITLE
Initialize artDmxCallback as NULL

### DIFF
--- a/src/ArtnetWifi.cpp
+++ b/src/ArtnetWifi.cpp
@@ -30,7 +30,7 @@ THE SOFTWARE.
 
 const char ArtnetWifi::artnetId[] = ART_NET_ID;
 
-ArtnetWifi::ArtnetWifi() {}
+ArtnetWifi::ArtnetWifi() : artDmxCallback(nullptr) {}
 
 void ArtnetWifi::begin(String hostname)
 {


### PR DESCRIPTION
When not explicitly setting `artDmxCallback` via `setArtDmxCallback()`, it may point to an invalid address other than NULL, since primitive pointers are not initialized by the compiler in c++.

Since `read()` tries to dereference `artDmxCallback` if it's not NULL,  the program may crash. 

As an easy fix, I suggest to initialize `artDmxCallback` as NULL in the initializer list.