### PR TITLE
Update ArtnetWifiFastLED.ino

### DIFF
--- a/examples/ArtnetWifiFastLED/ArtnetWifiFastLED.ino
+++ b/examples/ArtnetWifiFastLED/ArtnetWifiFastLED.ino
@@ -22,7 +22,7 @@ ArtnetWifi artnet;
 const int startUniverse = 0; // CHANGE FOR YOUR SETUP most software this is 1, some software send out artnet first universe as 0.
 
 // Check if we got all universes
-const int maxUniverses = numberOfChannels / 512 + ((numberOfChannels % 512) ? 1 : 0);
+const int maxUniverses = numberOfChannels / 510 + ((numberOfChannels % 510) ? 1 : 0);
 bool universesReceived[maxUniverses];
 bool sendFrame = 1;
 


### PR DESCRIPTION
For RGB strings only 510 cnannels per universe can be used (170*3), so for calculating maxUniverses we have to use 510 instead of 512